### PR TITLE
Fix exception on first opening of Pepyatka.

### DIFF
--- a/public/js/app/views/ApplicationView.js
+++ b/public/js/app/views/ApplicationView.js
@@ -1,5 +1,6 @@
 define(["app/app",
-        "text!templates/applicationTemplate.handlebars"], function(App, tpl) {
+        "text!templates/applicationTemplate.handlebars",
+        "app/helpers/components"], function(App, tpl) {
   App.ApplicationView = Ember.View.extend(App.ShowSpinnerWhileRendering, {
     templateName: 'application',
     template: Ember.Handlebars.compile(tpl),


### PR DESCRIPTION
Exception "Assertion Failed: Expected hash or Mixin instance, got [object Undefined] at ember.js:910" happens because App.ShowSpinnerWhileRendering is undefined. There was no explicit dependency on the JS file where this mixin is defined, so there was no guarantee that the JS file was loaded in the browser. The fix adds this dependency.