### PR TITLE
Fix layout for subscription/subscriber list (again)

### DIFF
--- a/themes/shared/lists.scss
+++ b/themes/shared/lists.scss
@@ -5,14 +5,15 @@ ul.tile-list {
   li {
     width: 110px;
     height: 110px;
-    display: inline-block;
+    display: block;
+    float: left;
     overflow: hidden;
     list-style-type: none;
     padding-top: 10px;
     text-align: center;
 
     a {
-      display: inline-block;
+      display: block;
       line-height: 130%;
       font-size: 12px;
       color: #4c4c4c;


### PR DESCRIPTION
Safari doesn't play well with `display: inline-block`.
Also, alignment for loooong one-word usernames is fixed.

Fixes #338 and #336.