### PR TITLE
Switch places of Hide and Like links in post info [Issue #330]

### DIFF
--- a/public/js/app/templates/postTemplate.handlebars
+++ b/public/js/app/templates/postTemplate.handlebars
@@ -44,11 +44,6 @@
           <a {{action 'focusCommentForm' target=view}} class="p-post-comment">Comment</a>
         {{/if}}
 
-        {{#if view.isOwner}}
-          (<a {{action 'toggleEditability'}} class="p-post-toggle-editability">Edit</a>
-          |
-          <a {{action 'destroy'}} class="p-post-destroy">Destroy</a>)
-        {{/if}}
         {{#if controller.session.signedIn}}
           -
           {{#if isLiked}}
@@ -56,6 +51,13 @@
           {{else}}
             <span><a {{action 'like'}} class="p-post-like">Like</a></span>
           {{/if}}
+        {{/if}}
+
+        {{#if view.isOwner}}
+          -
+          <a {{action 'toggleEditability'}} class="p-post-toggle-editability">Edit</a>
+          -
+          <a {{action 'destroy'}} class="p-post-destroy">Destroy</a>)
         {{/if}}
       </span>
 

--- a/public/js/app/templates/timelinePostTemplate.handlebars
+++ b/public/js/app/templates/timelinePostTemplate.handlebars
@@ -44,6 +44,15 @@
           <a {{action 'toggleCommentForm' target=view}} class="p-timeline-post-comment-action">Comment</a>
         {{/if}}
 
+        {{#if controller.session.signedIn}}
+          -
+          {{#if controller.isLiked}}
+            <span><a {{action 'unlike'}} class="p-timeline-post-unlike-action">Un-like</a></span>
+          {{else}}
+            <span><a {{action 'like'}} class="p-timeline-post-like-action">Like</a></span>
+          {{/if}}
+        {{/if}}
+
         {{#if view.parentView.parentView.isRiverOfNews}}
           -
           {{#if post.model.canHide}}
@@ -54,17 +63,10 @@
         {{/if}}
 
         {{#if view.isOwner}}
-          (<a {{action 'toggleEditability'}} class="p-timeline-post-edit-action">Edit</a>
-          |
-          <a {{action 'destroy'}} class="p-timeline-post-destroy-action">Destroy</a>)
-        {{/if}}
-        {{#if controller.session.signedIn}}
           -
-          {{#if controller.isLiked}}
-            <span><a {{action 'unlike'}} class="p-timeline-post-unlike-action">Un-like</a></span>
-          {{else}}
-            <span><a {{action 'like'}} class="p-timeline-post-like-action">Like</a></span>
-          {{/if}}
+          <a {{action 'toggleEditability'}} class="p-timeline-post-edit-action">Edit</a>
+          -
+          <a {{action 'destroy'}} class="p-timeline-post-destroy-action">Destroy</a>
         {{/if}}
       </span>
 


### PR DESCRIPTION
Switched places of Hide and Like links in post info to make it look like it was in the original FriendFeed. Also changed "(Edit | Destroy)" to " - Edit - Destroy" to conform to visual style of other links.