### PR TITLE
Css source map [2]

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -33,7 +33,8 @@ task('themes', function () {
       file: value,
       outFile: files[value],
       outputStyle: 'compressed',
-      sourceMap: true
+      sourceMap: true,
+      sourceMapContents: true
     })
 
     fs.writeFileSync(files[value], result.css)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "express": "4.9.5",
     "ejs": "0.8.3",
     "jake": "8.0.11",
-    "node-sass": "2.0.1",
+    "node-sass": "3.0.0",
     "requirejs": "2.1.16"
   }
 }


### PR DESCRIPTION
1. Require node-sass v3. sourceMap links broken in v2.
2. include scss in map files.