### PR TITLE
Unify whitespace around likes block

### DIFF
--- a/themes/helvetica/post.scss
+++ b/themes/helvetica/post.scss
@@ -16,7 +16,7 @@
   }
 
   .body {
-    margin-bottom: 10px;
+    margin-bottom: 8px;
 
     .text {
       color: #000;
@@ -68,7 +68,7 @@
       list-style: none;
       margin: 0;
       padding: 0;
-      margin: 0 4px 4px 21px;
+      margin: 0 4px 10px 21px;
       float: left;
     }
     ul li {


### PR DESCRIPTION
This commit fixes an issue with whitespace around likes block, making it more in line with whitespace around comments and post body.