### PR TITLE
Fix footer class name

### DIFF
--- a/public/js/app/templates/footerTemplate.handlebars
+++ b/public/js/app/templates/footerTemplate.handlebars
@@ -1,4 +1,4 @@
-<footer class="footer">
+<footer class="footer p-footer">
   Pepyatka 2012-2015 |
   <a href="https://github.com/pepyatka/pepyatka"><i class="fa fa-github-alt"></i> Github</a> |
   {{#link-to 'home'}}About{{/link-to}}

--- a/public/js/app/templates/footerTemplate.handlebars
+++ b/public/js/app/templates/footerTemplate.handlebars
@@ -1,4 +1,4 @@
-<footer class="p-footer">
+<footer class="footer">
   Pepyatka 2012-2015 |
   <a href="https://github.com/pepyatka/pepyatka"><i class="fa fa-github-alt"></i> Github</a> |
   {{#link-to 'home'}}About{{/link-to}}


### PR DESCRIPTION
The <footer> has a class name .p-footer with no style declarations and there's a .footer class name that is not attached to anything. Seems like a typo.