### PR TITLE
Предотвращение схлопывания контейнера для лайков

### DIFF
--- a/themes/helvetica/post.scss
+++ b/themes/helvetica/post.scss
@@ -50,6 +50,7 @@
 
   .likes {
     margin-top: 8px;
+    overflow: hidden;
     .icon-stack {
       height: auto;
       line-height: 0.9;


### PR DESCRIPTION
Сейчас контейнер схлопывается, и из-за этого лайки получаются ближе к комментариям, чем к посту.

Было:
![2015-05-08 16-59-25 freefeed - google chrome](https://cloud.githubusercontent.com/assets/132120/7537777/e0bfe310-f5a3-11e4-872a-54bbf4934285.png)

Станет:
![2015-05-08 16-59-49 freefeed - google chrome](https://cloud.githubusercontent.com/assets/132120/7537779/e5f01f12-f5a3-11e4-930e-3664a6a8cd09.png)
