### PR TITLE
commas: back to css solution

### DIFF
--- a/public/js/app/templates/postLikesTemplate.handlebars
+++ b/public/js/app/templates/postLikesTemplate.handlebars
@@ -6,30 +6,32 @@
 
   {{#if view.isHidden}}
     <ul class="p-timeline-user-likes">
-      {{#each  view.shownLikes as |user index|}}
+      {{#each user in view.shownLikes}}
         <li class="p-timeline-user-like">
-          {{#link-to 'timeline.index' user.username (query-params offset=0)}}{{user.screenName}}{{/link-to}}<!--
-          -->{{#unless (isLast index in view.shownLikes)}}, {{else}}
-              <span>
-                and
-                  <a {{action 'toggleHidden' target=view}}>{{view.hiddenLikes.length}} other people</a>
-                liked this
-              </span>
-             {{/unless}}
+          {{#link-to 'timeline.index' user.username (query-params offset=0)}}{{user.screenName}}{{/link-to}}<i>,</i>
         </li>
       {{/each}}
+      <li>
+        <span>
+          and
+          <a {{action 'toggleHidden' target=view}}>{{view.hiddenLikes.length}} other people</a>
+          liked this
+        </span>
+      </li>
     </ul>
 
   {{else}}
     <ul class="p-timeline-user-likes">
-      {{#each  view.likes as |user index|}}
+      {{#each user in view.likes}}
         <li class="p-timeline-user-like">
-          {{#link-to 'timeline.index' user.username (query-params offset=0)}}{{user.screenName}}{{/link-to}}<!--
-          -->{{#unless (isLast index in view.likes)}}, {{else}}
-              <span>liked this</span>
-             {{/unless}}
+          {{#link-to 'timeline.index' user.username (query-params offset=0)}}{{user.screenName}}{{/link-to}}<i>,</i>
         </li>
       {{/each}}
+      <li>
+        <span>
+          liked this
+        </span>
+      </li>
     </ul>
   {{/if}}
 </div>

--- a/themes/helvetica/post.scss
+++ b/themes/helvetica/post.scss
@@ -72,6 +72,12 @@
     }
     ul li {
       display: inline;
+      i {
+        font-style: normal;
+      }
+      &:nth-last-child(2) i {
+        display: none;
+      }
     }
   }
 }


### PR DESCRIPTION
Well, I spent some time trying to fix this weird behaviour but failed to do this in reasonable time. My suggestion is to rollback to css solution, or let someone more experienced in ember/handlebars to debug this. 

This is what I found: when view update is triggered by like or un-like, index inside `#each` loop acts weird. Each loop does not trigger index check for every element, only for new elements. This causes wrong index checks and incorrect display of items. You can see this video for more details:

https://www.dropbox.com/s/a64f24dz934y5hr/ember-wtf.mov?dl=0