### PR TITLE
URLs in posts: support for rich content links embedding

### DIFF
--- a/public/js/libs/plugins/jquery.anchorlinks.js
+++ b/public/js/libs/plugins/jquery.anchorlinks.js
@@ -16,46 +16,29 @@
         el.nodeValue = el.nodeValue.substring(0, el.nodeValue.indexOf(m[1]))
         tail.nodeValue = tail.nodeValue.substring(tail.nodeValue.indexOf(m[1]) + m[1].length)
 
-        var name = m[1]
-        var shorten = false
+        var url = m[1]
+          , urlParts
 
-        // shorten url if it's nested more than 2 levels, e.g. http://google.com/a/b
-        if (name.split('/').length > 4) {
-          name = name.split('/').slice(0, 4).join('/')
-          shorten = true
+        switch (true) {
+          default:
+            simpleLink(url, el, tail)
+            break;
+
+          case !!(urlParts = url.match(/^https?:\/\/coub.com\/(embed|view)\/([a-zA-Z0-9]+)/i)):
+            coubLink(urlParts[2], el, tail)
+            break;
+
+          case !!(urlParts = url.match(/^https?:\/\/instagram.com\/p\/([-_a-zA-Z0-9]+)/i)):
+            instagramLink(urlParts[1], el, tail)
+            break;
+
+          case !!(urlParts = url.match(/^https?:\/\/www.youtube.com\/watch\?v=([a-zA-Z0-9]+)/i)):
+          case !!(urlParts = url.match(/^https?:\/\/youtu.be\/([a-zA-Z0-9]+)/i)):
+          case !!(urlParts = url.match(/^https?:\/\/youtube.com\/embed\/([a-zA-Z0-9]+)/i)):
+            youtubeLink(urlParts[1], el, tail)
+            break;
+
         }
-
-        // shorten url after ? symbol e.g. http://google.com/a?123
-        if (name.split('?').length > 1) {
-          name = name.split('?')[0]
-          shorten = true
-        }
-
-        // shorten url after # symbol e.g. http://google.com/a#123
-        if (name.split('#').length > 1) {
-          name = name.split('#')[0]
-          shorten = true
-        }
-
-        // shorten url if it's longer than 7 symbols e.g. http://google.com/12345678
-        if (name.split('/').length == 4 &&
-           name.split('/')[3].length > 7) {
-          name = name.split('/').slice(0, 3).join('/') + '/' + name.split('/')[3].slice(0, 7)
-          shorten = true
-        }
-
-        if (shorten)
-          name = name + "&hellip;"
-
-        // Rebuild the DOM inserting the new anchor element between
-        // the split text nodes
-        $(el)
-          .after(tail)
-          .after($("<a></a>")
-                 .attr("title", m[1])
-                 .attr("href", m[1])
-                 .attr("target", "_blank")
-                 .html(name))
 
         // Recurse on the new tail node to check for more URLs
         testAndTag(tail)
@@ -63,6 +46,86 @@
 
       // Behave like a function
       return false
+    }
+
+    // parsers
+    var simpleLink = function(url, el, tail) {
+      var shorten = false
+        , name = url
+
+      // shorten url if it's nested more than 2 levels, e.g. http://google.com/a/b
+      if (name.split('/').length > 4) {
+        name = name.split('/').slice(0, 4).join('/')
+        shorten = true
+      }
+
+      // shorten url after ? symbol e.g. http://google.com/a?123
+      if (name.split('?').length > 1) {
+        name = name.split('?')[0]
+        shorten = true
+      }
+
+      // shorten url after # symbol e.g. http://google.com/a#123
+      if (name.split('#').length > 1) {
+        name = name.split('#')[0]
+        shorten = true
+      }
+
+      // shorten url if it's longer than 7 symbols e.g. http://google.com/12345678
+      if (name.split('/').length == 4 &&
+        name.split('/')[3].length > 7) {
+        name = name.split('/').slice(0, 3).join('/') + '/' + name.split('/')[3].slice(0, 7)
+        shorten = true
+      }
+
+      if (shorten)
+        name = name + "&hellip;"
+
+      // Rebuild the DOM inserting the new anchor element between
+      // the split text nodes
+      $(el)
+        .after(tail)
+        .after($("<a></a>")
+          .attr("title", url)
+          .attr("href", url)
+          .attr("target", "_blank")
+          .html(name))
+    }
+
+    var youtubeLink = function(youtubeId, el, tail) {
+      $(el).wrap('<p>')
+        .after(tail)
+        .after($("<iframe/>")
+          .attr("src", "//www.youtube.com/embed/"+youtubeId)
+          .attr("allowfullscreen", true)
+          .attr("frameborder", "0")
+          .attr("class", "embedded embedded-youtube")
+          .attr("width", "480")
+          .attr("height", "320"))
+    }
+
+    var coubLink = function(coubId, el, tail) {
+      $(el).wrap('<p>')
+        .after(tail)
+        .after($("<iframe/>")
+          .attr("src", "//coub.com/embed/"+coubId+"?autostart=false&originalSize=false&hideTopBar=true&startWithHD=false")
+          .attr("allowfullscreen", true)
+          .attr("frameborder", "0")
+          .attr("class", "embedded embedded-coub")
+          .attr("width", "480")
+          .attr("height", "320"))
+    }
+
+    var instagramLink = function(instagramId, el, tail) {
+      $(el)
+        .after(tail)
+        .after($("<iframe/>")
+          .attr("src", "//instagram.com/p/"+instagramId+"/embed/")
+          .attr("frameborder", "0")
+          .attr("class", "embedded embedded-instagram")
+          .attr("scrolling", "no")
+          .attr("width", "480")
+          .attr("height", "480"))
     }
 
     // For each element selected by jQuery

--- a/themes/helvetica/post.scss
+++ b/themes/helvetica/post.scss
@@ -19,6 +19,11 @@
     margin-bottom: 10px;
 
     .text {
+
+      .embedded {
+        display: block;
+      }
+
       color: #000;
 
       a {


### PR DESCRIPTION
Extends `anchorTextUrls` formatter that is used to make URLs in posts and comments clickable. Look for URLs that can be embedded and replace them with embedded content. 

@berkus suggests that we add user setting to turn this feature off  before deploying