### PR TITLE
Scroll to top fix 143

### DIFF
--- a/public/js/app/components/TransitionalRoute.js
+++ b/public/js/app/components/TransitionalRoute.js
@@ -1,0 +1,19 @@
+define(["app/app",
+        "ember"], function(App, Ember) {
+  "use strict";
+
+  App.TransitionalRoute = Ember.Mixin.create({
+
+    beforeModel: function() {
+      this._super()
+      Ember.$('body').addClass('transition-active')
+    },
+
+    afterModel: function() {
+      this._super()
+      window.scrollTo(0,0)
+      Ember.$('body').removeClass('transition-active')
+    }
+
+  })
+})

--- a/public/js/app/routes/ForgotPasswordRoute.js
+++ b/public/js/app/routes/ForgotPasswordRoute.js
@@ -1,6 +1,7 @@
-define(["app/app"], function(App) {
+define(["app/app",
+        "components/TransitionalRoute"], function(App) {
   "use strict";
 
-  App.ForgotPasswordRoute = Ember.Route.extend({
+  App.ForgotPasswordRoute = Ember.Route.extend(App.TransitionalRoute, {
   })
 })

--- a/public/js/app/routes/GroupsHomeRoute.js
+++ b/public/js/app/routes/GroupsHomeRoute.js
@@ -1,6 +1,7 @@
-define(["app/app"], function(App) {
+define(["app/app",
+        "components/TransitionalRoute"], function(App) {
   "use strict";
 
-  App.GroupsHomeRoute = Ember.Route.extend({
+  App.GroupsHomeRoute = Ember.Route.extend(App.TransitionalRoute, {
   })
 })

--- a/public/js/app/routes/GroupsNewRoute.js
+++ b/public/js/app/routes/GroupsNewRoute.js
@@ -1,6 +1,7 @@
-define(["app/app"], function(App) {
+define(["app/app",
+        "components/TransitionalRoute"], function(App) {
   "use strict";
 
-  App.GroupsNewRoute = Ember.Route.extend({
+  App.GroupsNewRoute = Ember.Route.extend(App.TransitionalRoute, {
   })
 })

--- a/public/js/app/routes/HomeRoute.js
+++ b/public/js/app/routes/HomeRoute.js
@@ -1,6 +1,7 @@
-define(["app/app"], function(App) {
+define(["app/app",
+        "components/TransitionalRoute"], function(App) {
   "use strict";
 
-  App.HomeRoute = Ember.Route.extend({
+  App.HomeRoute = Ember.Route.extend(App.TransitionalRoute, {
   })
 })

--- a/public/js/app/routes/NotFoundRoute.js
+++ b/public/js/app/routes/NotFoundRoute.js
@@ -1,6 +1,7 @@
-define(["app/app"], function(App) {
+define(["app/app",
+        "components/TransitionalRoute"], function(App) {
   "use strict";
 
-  App.NotFoundRoute = Ember.Route.extend({
+  App.NotFoundRoute = Ember.Route.extend(App.TransitionalRoute, {
   })
 })

--- a/public/js/app/routes/PostRoute.js
+++ b/public/js/app/routes/PostRoute.js
@@ -1,8 +1,9 @@
 define(["app/app",
-        "ember"], function(App, Emberx) {
+        "ember",
+        "components/TransitionalRoute"], function(App, Ember) {
   "use strict";
 
-  App.PostRoute = Ember.Route.extend({
+  App.PostRoute = Ember.Route.extend(App.TransitionalRoute, {
     deactivate: function() {
       this.controllerFor('pub-sub').unsubscribe()
     },

--- a/public/js/app/routes/ResetPasswordRoute.js
+++ b/public/js/app/routes/ResetPasswordRoute.js
@@ -1,6 +1,7 @@
-define(["app/app"], function(App) {
+define(["app/app",
+        "components/TransitionalRoute"], function(App) {
   "use strict";
 
-  App.ResetPasswordRoute = Ember.Route.extend({
+  App.ResetPasswordRoute = Ember.Route.extend(App.TransitionalRoute, {
   })
 })

--- a/public/js/app/routes/SessionDestroyRoute.js
+++ b/public/js/app/routes/SessionDestroyRoute.js
@@ -1,7 +1,8 @@
-define(["app/app"], function(App) {
+define(["app/app",
+        "components/TransitionalRoute"], function(App) {
   "use strict";
 
-  App.SessionDestroyRoute = Ember.Route.extend({
+  App.SessionDestroyRoute = Ember.Route.extend(App.TransitionalRoute, {
     setupController: function(controller, model) {
       controller.send('logout')
     }

--- a/public/js/app/routes/SessionNewRoute.js
+++ b/public/js/app/routes/SessionNewRoute.js
@@ -1,6 +1,7 @@
-define(["app/app"], function(App) {
+define(["app/app",
+        "components/TransitionalRoute"], function(App) {
   "use strict";
 
-  App.SessionNewRoute = Ember.Route.extend({
+  App.SessionNewRoute = Ember.Route.extend(App.TransitionalRoute, {
   })
 })

--- a/public/js/app/routes/SettingsFeedRoute.js
+++ b/public/js/app/routes/SettingsFeedRoute.js
@@ -1,8 +1,10 @@
-define(["app/app"], function(App) {
+define(["app/app",
+        "components/TransitionalRoute"], function(App) {
   "use strict";
 
-  App.SettingsFeedRoute = Ember.Route.extend({
+  App.SettingsFeedRoute = Ember.Route.extend(App.TransitionalRoute, {
     beforeModel: function() {
+      this._super.apply(this, arguments)
       if (!this.get('session.currentUser'))
         return this.transitionTo('session.new')
     },

--- a/public/js/app/routes/SettingsIndexRoute.js
+++ b/public/js/app/routes/SettingsIndexRoute.js
@@ -1,8 +1,10 @@
-define(["app/app"], function(App) {
+define(["app/app",
+        "components/TransitionalRoute"], function(App) {
   "use strict";
 
-  App.SettingsRoute = Ember.Route.extend({
+  App.SettingsRoute = Ember.Route.extend(App.TransitionalRoute, {
     beforeModel: function() {
+      this._super.apply(this, arguments)
       if (!this.get('session.currentUser'))
         return this.transitionTo('session.new')
     },

--- a/public/js/app/routes/TimelineCommentsRoute.js
+++ b/public/js/app/routes/TimelineCommentsRoute.js
@@ -1,7 +1,8 @@
-define(["app/app"], function(App) {
+define(["app/app",
+        "components/TransitionalRoute"], function(App) {
   "use strict";
 
-  App.TimelineCommentsRoute = Ember.Route.extend({
+  App.TimelineCommentsRoute = Ember.Route.extend(App.TransitionalRoute, {
     queryParams: {
       offset: {
         refreshModel: true

--- a/public/js/app/routes/TimelineDiscussionsRoute.js
+++ b/public/js/app/routes/TimelineDiscussionsRoute.js
@@ -1,7 +1,8 @@
-define(["app/app"], function(App) {
+define(["app/app",
+        "components/TransitionalRoute"], function(App) {
   "use strict";
 
-  App.TimelineDiscussionsRoute = Ember.Route.extend({
+  App.TimelineDiscussionsRoute = Ember.Route.extend(App.TransitionalRoute, {
     queryParams: {
       offset: {
         refreshModel: true
@@ -9,6 +10,7 @@ define(["app/app"], function(App) {
     },
 
     beforeModel: function() {
+      this._super.apply(this, arguments)
       if (!this.get('session.currentUser'))
         return this.transitionTo('session.new')
     },

--- a/public/js/app/routes/TimelineHomeRoute.js
+++ b/public/js/app/routes/TimelineHomeRoute.js
@@ -1,7 +1,8 @@
-define(["app/app"], function(App) {
+define(["app/app",
+        "components/TransitionalRoute"], function(App) {
   "use strict";
 
-  App.TimelineHomeRoute = Ember.Route.extend({
+  App.TimelineHomeRoute = Ember.Route.extend(App.TransitionalRoute,{
     queryParams: {
       offset: {
         refreshModel: true
@@ -9,6 +10,7 @@ define(["app/app"], function(App) {
     },
 
     beforeModel: function() {
+      this._super.apply(this, arguments)
       if (!this.get('session.currentUser'))
         return this.transitionTo('session.new')
     },

--- a/public/js/app/routes/TimelineIndexRoute.js
+++ b/public/js/app/routes/TimelineIndexRoute.js
@@ -1,7 +1,8 @@
-define(["app/app"], function(App) {
+define(["app/app",
+        "components/TransitionalRoute"], function(App) {
   "use strict";
 
-  App.TimelineIndexRoute = Ember.Route.extend({
+  App.TimelineIndexRoute = Ember.Route.extend(App.TransitionalRoute, {
     queryParams: {
       offset: {
         refreshModel: true

--- a/public/js/app/routes/TimelineLikesRoute.js
+++ b/public/js/app/routes/TimelineLikesRoute.js
@@ -1,7 +1,8 @@
-define(["app/app"], function(App) {
+define(["app/app",
+        "components/TransitionalRoute"], function(App) {
   "use strict";
 
-  App.TimelineLikesRoute = Ember.Route.extend({
+  App.TimelineLikesRoute = Ember.Route.extend(App.TransitionalRoute, {
     queryParams: {
       offset: {
         refreshModel: true

--- a/public/js/app/routes/TimelineSubscribersRoute.js
+++ b/public/js/app/routes/TimelineSubscribersRoute.js
@@ -1,7 +1,8 @@
-define(["app/app"], function(App) {
+define(["app/app",
+        "components/TransitionalRoute"], function(App) {
   "use strict";
 
-  App.TimelineSubscribersRoute = Ember.Route.extend({
+  App.TimelineSubscribersRoute = Ember.Route.extend(App.TransitionalRoute, {
     actions: {
       error: function (error) {
         this.transitionTo('not-found')

--- a/public/js/app/routes/TimelineSubscriptionsRoute.js
+++ b/public/js/app/routes/TimelineSubscriptionsRoute.js
@@ -1,7 +1,8 @@
-define(["app/app"], function(App) {
+define(["app/app",
+        "components/TransitionalRoute"], function(App) {
   "use strict";
 
-  App.TimelineSubscriptionsRoute = Ember.Route.extend({
+  App.TimelineSubscriptionsRoute = Ember.Route.extend(App.TransitionalRoute, {
     actions: {
       error: function (error) {
         this.transitionTo('not-found')

--- a/public/js/app/routes/UsersNewRoute.js
+++ b/public/js/app/routes/UsersNewRoute.js
@@ -1,6 +1,7 @@
-define(["app/app"], function(App) {
+define(["app/app",
+        "components/TransitionalRoute"], function(App) {
   "use strict";
 
-  App.UsersNewRoute = Ember.Route.extend({
+  App.UsersNewRoute = Ember.Route.extend(App.TransitionalRoute, {
   })
 })

--- a/themes/helvetica/base.scss
+++ b/themes/helvetica/base.scss
@@ -2,6 +2,20 @@ body {
   background: #FFF;
 }
 
+body.transition-active:before {
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  content: "";
+  opacity: 0.8;
+  z-index: 1;
+  background:
+    #fff
+    url('/img/uploading.gif')
+    no-repeat
+    center;
+}
+
 @media (min-width: 1200px){
   .container {
     width: 961px;


### PR DESCRIPTION
fixes #143 : scroll to top after route transition and when `afterModel` is triggered. Also added css class `.transition-active` to body element when route transition is active (between `beforeModel` and `afterModel`) this allows to create simple loader indicator