### PR TITLE
Даты создания постов и комментариев в машиночитаемом виде

### DIFF
--- a/public/js/app/models/Comment.js
+++ b/public/js/app/models/Comment.js
@@ -15,6 +15,13 @@ define(["app/app",
       if (this.get('createdAt')) {
         return moment(this.get('createdAt')).fromNow()
       }
-    }.property('createdAt')
+    }.property('createdAt'),
+
+    createdAtISO: function() {
+      if (this.get('createdAt')) {
+        return moment(this.get('createdAt')).format()
+      }
+    }.property('createdAt'),
+
   })
 })

--- a/public/js/app/models/Post.js
+++ b/public/js/app/models/Post.js
@@ -36,6 +36,12 @@ define(["config",
       }
     }.property('createdAt'),
 
+    createdAtISO: function() {
+      if (this.get('createdAt')) {
+        return moment(this.get('createdAt')).format()
+      }
+    }.property('createdAt'),
+
     like: function() {
       return Ember.$.ajax({
         url: this.resourceUrl + '/' + this.get('id') + '/like',

--- a/public/js/app/templates/postCommentTemplate.handlebars
+++ b/public/js/app/templates/postCommentTemplate.handlebars
@@ -1,5 +1,6 @@
 <div class="comment p-comment">
   <a class="date" {{bind-attr title="comment.model.createdAgo"}}>
+    <time {{bind-attr datetime="comment.model.createdAtISO"}}></time>
     <i class="fa fa-comment-o icon"></i>
   </a>
 

--- a/public/js/app/templates/postTemplate.handlebars
+++ b/public/js/app/templates/postTemplate.handlebars
@@ -36,7 +36,7 @@
 
     <div class="info">
       <span class="post-date">
-        {{#link-to 'post' model.createdBy.username content.id (query-params offset=0) class="datetime"}}<time {{bind-attr datetime="model.createdAgo"}}>{{model.createdAgo}}</time>{{/link-to}}
+        {{#link-to 'post' model.createdBy.username content.id (query-params offset=0) class="datetime"}}<time {{bind-attr datetime="model.createdAtISO"}}>{{model.createdAgo}}</time>{{/link-to}}
       </span>
 
       <span class="post-controls">


### PR DESCRIPTION
По стандарту, в атрибуте `datetime` тега `time` должно быть время в машиночитаемом виде. Данный патч исправляет время в шаблоне поста и добавляет тег `time` в шаблон комментария.