### PR TITLE
Дата создания поста в машиночитаемом виде (в таймлайне)

### DIFF
--- a/public/js/app/templates/timelinePostTemplate.handlebars
+++ b/public/js/app/templates/timelinePostTemplate.handlebars
@@ -36,7 +36,7 @@
 
     <div class="info p-timeline-post-info">
       <span class="post-date">
-        {{#link-to 'post' post.content.createdBy.username post.content.id (query-params offset=0) class="datetime"}}<time {{bind-attr datetime="post.model.createdAgo"}}>{{post.model.createdAgo}}</time>{{/link-to}}
+        {{#link-to 'post' post.content.createdBy.username post.content.id (query-params offset=0) class="datetime"}}<time {{bind-attr datetime="post.model.createdAtISO"}}>{{post.model.createdAgo}}</time>{{/link-to}}
       </span>
 
       <span class="post-controls">


### PR DESCRIPTION
Это дополнение к пулл-реквесту #380 — там я упустил шаблон поста в таймлайне, и в нём всё осталось по-старому.