### PR TITLE
Hyphen between post time and post controls

### DIFF
--- a/themes/helvetica/post.scss
+++ b/themes/helvetica/post.scss
@@ -77,4 +77,8 @@
       }
     }
   }
+  
+  .post-controls::before {
+    content: "-";
+  }
 }


### PR DESCRIPTION
Так было в старом Фидике. Некоторые по этому минусу скучают: https://freefeed.net/bugreport/d82ac35b-0366-4f87-9b2a-429c05b72a15?offset=0

![5-0009-new list](https://cloud.githubusercontent.com/assets/132120/8315526/09c37ca2-19fa-11e5-86c1-e01f4ab0fa23.png)
