### PR TITLE
Fix an overlap of the first audio attachment on small screens

### DIFF
--- a/themes/fresh/post.scss
+++ b/themes/fresh/post.scss
@@ -88,7 +88,7 @@
 
   .audio-attachments {
     .attachment {
-      display: block;
+      display: inline-block;
       margin: 0 8px 8px 0;
 
       .full-player {
@@ -116,7 +116,7 @@
 
   .general-attachments {
     .attachment {
-      display: block;
+      display: inline-block;
       margin: 0 8px 8px 0;
     }
   }

--- a/themes/helvetica/post.scss
+++ b/themes/helvetica/post.scss
@@ -92,7 +92,7 @@
 
   .audio-attachments {
     .attachment {
-      display: block;
+      display: inline-block;
       margin: 0 8px 8px 0;
 
       .full-player {
@@ -116,7 +116,7 @@
 
   .general-attachments {
     .attachment {
-      display: block;
+      display: inline-block;
       margin: 0 8px 8px 0;
     }
   }


### PR DESCRIPTION
Before:

> <img width="506" alt="2015-07-22 00-28-33 pepyatka" src="https://cloud.githubusercontent.com/assets/1071933/8814047/a0f63190-3008-11e5-9d8d-bbeeb6d3478d.png">

After:

> <img width="514" alt="2015-07-22 00-27-06 pepyatka" src="https://cloud.githubusercontent.com/assets/1071933/8814033/7afe4392-3008-11e5-8603-56d495b80ffc.png">
