### PR TITLE
Attachment link bugfixes

### DIFF
--- a/public/js/app/controllers/PostAttachmentController.js
+++ b/public/js/app/controllers/PostAttachmentController.js
@@ -4,11 +4,11 @@ define(["app/app",
   "use strict";
 
   App.PostAttachmentController = Ember.Controller.extend({
-    tooltip: function() {
+    nameAndSize: function() {
       var fileName = this.get('model.fileName')
       var fileSize = this.get('model.fileSize')
       fileSize = numeral(fileSize).format('0.[0] b')
       return fileName + ' (' + fileSize + ')'
-    }.property()
+    }.property('model.fileName', 'model.fileSize')
   })
 })

--- a/public/js/app/models/Attachment.js
+++ b/public/js/app/models/Attachment.js
@@ -26,17 +26,6 @@ define(["app/app"], function(App) {
 
     isAudio: function() {
       return this.get('mediaType') === 'audio'
-    }.property('mediaType'),
-
-    formatSize: function() {
-      var decimals = 2
-      var bytes = this.get('fileSize')
-
-      if (bytes == 0) return '0 Byte'
-      var k = 1000
-      var sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
-      var i = Math.floor(Math.log(bytes) / Math.log(k))
-      return (bytes / Math.pow(k, i)).toFixed(decimals) + ' ' + sizes[i]
-    }.property('fileSize')
+    }.property('mediaType')
   })
 })

--- a/public/js/app/templates/postAttachmentTemplate.handlebars
+++ b/public/js/app/templates/postAttachmentTemplate.handlebars
@@ -1,8 +1,8 @@
 <div class="attachment">
   {{#if attachment.model.isImage}}
-    <a href="{{attachment.model.url}}" title="{{attachment.tooltip}}" class="p-attachment-url" target="_blank">
+    <a href="{{attachment.model.url}}" title="{{attachment.nameAndSize}}" class="p-attachment-url" target="_blank">
       {{#if attachment.model.thumbnailUrl}}
-        <img class="p-attachment-thumbnail" src="{{attachment.model.thumbnailUrl}}" alt="{{attachment.tooltip}}" />
+        <img class="p-attachment-thumbnail" src="{{attachment.model.thumbnailUrl}}" alt="{{attachment.nameAndSize}}" />
       {{else}}
         {{attachment.model.id}}
       {{/if}}
@@ -10,9 +10,9 @@
   {{/if}}
 
   {{#if attachment.model.isGeneral}}
-    <a href="{{attachment.model.url}}" title="{{attachment.tooltip}}" class="p-attachment-url" target="_blank">
-      <i class="fa fa-file-o"></i> {{attachment.model.fileName}}
-      <span class="muted">({{attachment.model.formatSize}})</span>
+    <a href="{{attachment.model.url}}" title="{{attachment.nameAndSize}}" class="p-attachment-url" target="_blank">
+      <i class="fa fa-file-o"></i>
+      {{attachment.nameAndSize}}
     </a>
   {{/if}}
 
@@ -23,9 +23,9 @@
       </div>
       {{view 'audio-player' playerId=attachment.model.id}}
       <div class="attachment-wrapper">
-        <a href="{{attachment.model.url}}" title="{{attachment.tooltip}}" class="p-attachment-url" target="_blank">
-          <i class="fa fa-file-audio-o"></i> {{attachment.model.fileName}}
-          <span class="muted">({{attachment.model.formatSize}})</span>
+        <a href="{{attachment.model.url}}" title="{{attachment.nameAndSize}}" class="p-attachment-url" target="_blank">
+          <i class="fa fa-file-audio-o"></i>
+          {{attachment.nameAndSize}}
         </a>
       </div>
     </div>

--- a/public/js/app/templates/postAttachmentTemplate.handlebars
+++ b/public/js/app/templates/postAttachmentTemplate.handlebars
@@ -9,13 +9,6 @@
     </a>
   {{/if}}
 
-  {{#if attachment.model.isGeneral}}
-    <a href="{{attachment.model.url}}" title="{{attachment.nameAndSize}}" class="p-attachment-url" target="_blank">
-      <i class="fa fa-file-o"></i>
-      {{attachment.nameAndSize}}
-    </a>
-  {{/if}}
-
   {{#if attachment.model.isAudio}}
     <div class="audio-wrapper">
       <div class="inner">
@@ -25,9 +18,16 @@
       <div class="attachment-wrapper">
         <a href="{{attachment.model.url}}" title="{{attachment.nameAndSize}}" class="p-attachment-url" target="_blank">
           <i class="fa fa-file-audio-o"></i>
-          {{attachment.nameAndSize}}
+          <span>{{attachment.nameAndSize}}</span>
         </a>
       </div>
     </div>
+  {{/if}}
+
+  {{#if attachment.model.isGeneral}}
+    <a href="{{attachment.model.url}}" title="{{attachment.nameAndSize}}" class="p-attachment-url" target="_blank">
+      <i class="fa fa-file-o"></i>
+      <span>{{attachment.nameAndSize}}</span>
+    </a>
   {{/if}}
 </div>

--- a/themes/fresh/post.scss
+++ b/themes/fresh/post.scss
@@ -32,6 +32,11 @@
 
     a {
       color: #0000cc;
+      text-decoration: none;
+
+      &:hover span {
+        text-decoration: underline;
+      }
     }
 
     // Clearfix (http://www.cssmojo.com/latest_new_clearfix_so_far/)

--- a/themes/helvetica/post.scss
+++ b/themes/helvetica/post.scss
@@ -32,6 +32,11 @@
 
     a {
       color: #000088;
+      text-decoration: none;
+
+      &:hover span {
+        text-decoration: underline;
+      }
     }
 
     // Clearfix (http://www.cssmojo.com/latest_new_clearfix_so_far/)


### PR DESCRIPTION
- Replace "formatSize" with unified "nameAndSize" (audio attachments). Fixes #583.
- Fix underlining in attachment links. This removes underline between icon and text.
