### PR TITLE
Attachment types & upload progress

### DIFF
--- a/public/js/app/adapters/FormDataAdapter.js
+++ b/public/js/app/adapters/FormDataAdapter.js
@@ -12,6 +12,8 @@ define(["app/app",
       hash.dataType = 'json'
       hash.context = this
 
+      var fileName = hash.data.attachment.file.name
+
       if (hash.data && type !== 'GET' && type !== 'DELETE') {
         hash.processData = false
         hash.contentType = false
@@ -27,11 +29,29 @@ define(["app/app",
 
       var headers = this.get('headers')
       if (headers !== undefined) {
-        hash.beforeSend = function (xhr) {
+        hash.beforeSend = function(xhr) {
           Ember.keys(headers).forEach(function(key) {
             xhr.setRequestHeader(key, headers[key])
           })
         }
+      }
+
+      hash.xhr = function() {
+        var xhr = new window.XMLHttpRequest()
+
+        // Upload progress
+        xhr.upload.addEventListener('progress', function(event) {
+          if (event.lengthComputable) {
+            var percentComplete = Math.round(event.loaded / event.total * 100)
+            Ember.$('.create-post .attachment').trigger({
+              type: 'upload-progress',
+              fileName: fileName,
+              percentComplete: percentComplete
+            })
+          }
+        }, false)
+
+        return xhr
       }
 
       return hash

--- a/public/js/app/controllers/PostAttachmentController.js
+++ b/public/js/app/controllers/PostAttachmentController.js
@@ -5,6 +5,12 @@ define(["app/app",
   "use strict";
 
   App.PostAttachmentController = App.ApplicationController.extend({
+
+    // 'uploadProgress' should be an instance property (set on init), not a prototype property
+    setupUploadProgress: function() {
+      this.set('uploadProgress', 0);
+    }.on('init'),
+
     nameAndSize: function() {
       var fileName = this.get('model.fileName')
       var fileSize = this.get('model.fileSize')
@@ -27,6 +33,15 @@ define(["app/app",
       } else {
         return fileName + ' (' + fileSize + ')'
       }
-    }.property('model.fileName', 'model.fileSize', 'model.title', 'model.artist')
+    }.property('model.fileName', 'model.fileSize', 'model.title', 'model.artist'),
+
+    actions: {
+      updateUploadProgress: function(fileName, percentComplete) {
+        // Only update progress if the event is intended for current file
+        if (this.get('model.fileName') === fileName) {
+          this.set('uploadProgress', percentComplete)
+        }
+      }
+    }
   })
 })

--- a/public/js/app/controllers/TimelineGenericController.js
+++ b/public/js/app/controllers/TimelineGenericController.js
@@ -117,7 +117,7 @@ define(["config",
 
         // Add a throbber (placeholder object, to show uploading progress)
         var attachmentList = this.get('attachments')
-        var throbber = this.store.createRecord('attachment', { thumbnailUrl: '/img/throbber-100.gif' })
+        var throbber = this.store.createRecord('attachment', { fileName: file.name })
         var throbberIndex = attachmentList.length
         attachmentList.pushObject(throbber)
 
@@ -128,7 +128,7 @@ define(["config",
             attachmentList.replace(throbberIndex, 1, [ attachment ])
           })
           .catch(function(e) {
-            console.log('upload failed')
+            console.log('Upload failed.')
             attachmentList.removeAt(throbberIndex, 1)
           })
       },

--- a/public/js/app/models/Attachment.js
+++ b/public/js/app/models/Attachment.js
@@ -19,8 +19,7 @@ define(["app/app"], function(App) {
     post: DS.belongsTo('post'),
 
     isImage: function() {
-      return this.get('mediaType') === 'image' ||
-        Ember.isEmpty(this.get('mediaType'))
+      return this.get('mediaType') === 'image'
     }.property('mediaType'),
 
     isGeneral: function() {
@@ -29,6 +28,10 @@ define(["app/app"], function(App) {
 
     isAudio: function() {
       return this.get('mediaType') === 'audio'
-    }.property('mediaType')
+    }.property('mediaType'),
+
+    isUploading: function() {
+      return this.get('id') === null
+    }.property('id')
   })
 })

--- a/public/js/app/templates/postAttachmentTemplate.handlebars
+++ b/public/js/app/templates/postAttachmentTemplate.handlebars
@@ -30,4 +30,14 @@
       <span>{{attachment.nameAndSize}}</span>
     </a>
   {{/if}}
+
+  {{#if attachment.model.isUploading}}
+    <a href="{{attachment.model.url}}" title="{{attachment.nameAndSize}}" class="p-attachment-url" target="_blank">
+      {{#if attachment.model.thumbnailUrl}}
+        <img class="p-attachment-thumbnail" src="{{attachment.model.thumbnailUrl}}" alt="{{attachment.nameAndSize}}" />
+      {{else}}
+        {{attachment.model.id}}
+      {{/if}}
+    </a>
+  {{/if}}
 </div>

--- a/public/js/app/templates/postAttachmentTemplate.handlebars
+++ b/public/js/app/templates/postAttachmentTemplate.handlebars
@@ -32,12 +32,8 @@
   {{/if}}
 
   {{#if attachment.model.isUploading}}
-    <a href="{{attachment.model.url}}" title="{{attachment.nameAndSize}}" class="p-attachment-url" target="_blank">
-      {{#if attachment.model.thumbnailUrl}}
-        <img class="p-attachment-thumbnail" src="{{attachment.model.thumbnailUrl}}" alt="{{attachment.nameAndSize}}" />
-      {{else}}
-        {{attachment.model.id}}
-      {{/if}}
-    </a>
+    <div class="upload-progress progress-{{attachment.uploadProgress}}" title="{{attachment.model.fileName}}">
+      <div class="center">{{attachment.uploadProgress}}%</div>
+    </div>
   {{/if}}
 </div>

--- a/public/js/app/templates/postTemplate.handlebars
+++ b/public/js/app/templates/postTemplate.handlebars
@@ -41,6 +41,7 @@
             {{view "post-attachment" content=attachment}}
           {{~/each~}}
         </div>
+
         <div class="general-attachments">
           {{~#each attachment in content.generalAttachments itemController="post-attachment"~}}
             {{view "post-attachment" content=attachment}}

--- a/public/js/app/templates/submitPostTemplate.handlebars
+++ b/public/js/app/templates/submitPostTemplate.handlebars
@@ -14,9 +14,37 @@
       <div class="col-md-10">
         {{#if controller.attachments}}
           <div class="attachments">
-            {{#each attachment in controller.attachments itemController="post-attachment"}}
-              {{view "post-attachment" content=attachment}}
-            {{/each}}
+            <div class="image-attachments">
+              {{~#each attachment in controller.attachments itemController="post-attachment"~}}
+                {{#if attachment.model.isImage}}
+                  {{view "post-attachment" content=attachment}}
+                {{/if}}
+              {{~/each~}}
+            </div>
+
+            <div class="audio-attachments">
+              {{~#each attachment in controller.attachments itemController="post-attachment"~}}
+                {{#if attachment.model.isAudio}}
+                  {{view "post-attachment" content=attachment}}
+                {{/if}}
+              {{~/each~}}
+            </div>
+
+            <div class="general-attachments">
+              {{~#each attachment in controller.attachments itemController="post-attachment"~}}
+                {{#if attachment.model.isGeneral}}
+                  {{view "post-attachment" content=attachment}}
+                {{/if}}
+              {{~/each~}}
+            </div>
+
+            <div class="uploading-attachments">
+              {{~#each attachment in controller.attachments itemController="post-attachment"~}}
+                {{#if attachment.model.isUploading}}
+                  {{view "post-attachment" content=attachment}}
+                {{/if}}
+              {{~/each~}}
+            </div>
           </div>
         {{/if}}
 

--- a/public/js/app/views/PostAttachmentView.js
+++ b/public/js/app/views/PostAttachmentView.js
@@ -2,6 +2,14 @@ define(["app/app",
         "text!templates/postAttachmentTemplate.handlebars"], function(App, tpl) {
   App.PostAttachmentView = Ember.View.extend({
     templateName: 'post-attachment',
-    template: Ember.Handlebars.compile(tpl)
+    template: Ember.Handlebars.compile(tpl),
+
+    didInsertElement: function() {
+      var that = this;
+
+      this.$().on('upload-progress', function (event) {
+        that.get('controller').send('updateUploadProgress', event.fileName, event.percentComplete);
+      });
+    }
   })
 })

--- a/themes/fresh/post.scss
+++ b/themes/fresh/post.scss
@@ -114,7 +114,7 @@
 
       i {
         color: #666666;
-        padding-right: 1px;
+        padding: 0 1px;
       }
     }
   }
@@ -126,7 +126,7 @@
 
       i {
         color: #666666;
-        padding-right: 1px;
+        padding: 0 1px;
       }
     }
   }

--- a/themes/helvetica/post.scss
+++ b/themes/helvetica/post.scss
@@ -114,7 +114,7 @@
 
       i {
         color: #666666;
-        padding-right: 1px;
+        padding: 0 1px;
       }
     }
   }
@@ -126,7 +126,7 @@
 
       i {
         color: #666666;
-        padding-right: 1px;
+        padding: 0 1px;
       }
     }
   }

--- a/themes/shared/create-post.scss
+++ b/themes/shared/create-post.scss
@@ -74,9 +74,53 @@
     .attachment {
       display: inline-block;
       vertical-align: middle;
-      border: 1px solid silver;
-      padding: 1px;
       margin: 0 8px 8px 0;
+
+      // Progress colors
+      $progressCircleColor: #d43e1b;
+      $progressCenterColor: #ffffff;
+      $progressBackgroundColor: #f9b616;
+
+      // Progress container
+      .upload-progress {
+        width: 100px;
+        height: 100px;
+        border-radius: 50%;
+        background-color: $progressCircleColor; // default 100%
+      }
+
+      // Mixin for progress-% classes
+      $step: 1; // step of % for created classes
+      $loops: round(100 / $step);
+      $increment: 360 / $loops;
+      $half: round($loops / 2);
+      @for $i from 0 through $loops {
+        .progress-#{$i*$step} {
+          @if $i < $half {
+            $nextdeg: 90deg + ( $increment * $i );
+            background-image: linear-gradient(90deg, $progressBackgroundColor 50%, transparent 50%, transparent),
+              linear-gradient($nextdeg, $progressCircleColor 50%, $progressBackgroundColor 50%, $progressBackgroundColor);
+          } @else {
+            $nextdeg: -90deg + ( $increment * ( $i - $half ) );
+            background-image: linear-gradient($nextdeg, $progressCircleColor 50%, transparent 50%, transparent),
+              linear-gradient(270deg, $progressCircleColor 50%, $progressBackgroundColor 50%, $progressBackgroundColor);
+          }
+        }
+      }
+
+      // Centered circle with text
+      .upload-progress .center {
+        position: absolute;
+        width: 54px;
+        height: 54px;
+        background-color: $progressCenterColor;
+        border-radius: 50%;
+        margin-left: 23px;
+        margin-top: 23px;
+        color: #888888;
+        text-align: center;
+        line-height: 54px;
+      }
     }
   }
 

--- a/themes/shared/create-post.scss
+++ b/themes/shared/create-post.scss
@@ -4,7 +4,7 @@
   margin-bottom: 14px;
 
   .attachments {
-    margin: 0 0 10px 0;
+    margin: 0 0 5px 0;
 
     // Clearfix (http://www.cssmojo.com/latest_new_clearfix_so_far/)
     &:after {
@@ -12,11 +12,26 @@
       display: table;
       clear: both;
     }
+  }
+
+  .image-attachments {
+    > .ember-view {
+      display: inline-block;
+      vertical-align: middle;
+    }
 
     .attachment {
-      float: left;
+      display: inline-block;
+      vertical-align: middle;
       border: 1px solid silver;
       padding: 1px;
+      margin: 0 8px 8px 0;
+    }
+  }
+
+  .audio-attachments {
+    .attachment {
+      display: inline-block;
       margin: 0 8px 8px 0;
 
       .full-player {
@@ -25,17 +40,43 @@
 
       .audio-wrapper {
         position: relative;
-      }
 
-      .audio-wrapper .inner {
-        padding-top: .45em;
-        padding-bottom: .3em;
+        .inner {
+          padding-bottom: 5px;
+        }
       }
 
       i {
         color: #666666;
-        padding-right: 1px;
+        padding: 0 1px;
       }
+    }
+  }
+
+  .general-attachments {
+    .attachment {
+      display: inline-block;
+      margin: 0 8px 8px 0;
+
+      i {
+        color: #666666;
+        padding: 0 1px;
+      }
+    }
+  }
+
+  .uploading-attachments {
+    > .ember-view {
+      display: inline-block;
+      vertical-align: middle;
+    }
+
+    .attachment {
+      display: inline-block;
+      vertical-align: middle;
+      border: 1px solid silver;
+      padding: 1px;
+      margin: 0 8px 8px 0;
     }
   }
 


### PR DESCRIPTION
- Add proper support for attachment types on create-post:
  images first, then audio, then other files, and progress throbbers last.
- Add upload progress for attachments (mmmm... radial ones)

As usual, you can test it at http://frf.creagenics.com:3333/
