### PR TITLE
Update localStorage->cookie migration

### DIFF
--- a/public/js/auth_storage.js
+++ b/public/js/auth_storage.js
@@ -1,29 +1,31 @@
 "use strict"
 
-define(["config"], function(config){
-  return{
+define(["config"], function(config) {
+  return {
     _isLocalStorageSupported: null,
+
     checkIfLocalStorageSupported: function() {
       var supported = ('localStorage' in window && window.localStorage !== null)
 
       if (!supported) {
-	return false
+        return false
       }
 
       var testKey = 'test'
 
       try {
-	window.localStorage.setItem(testKey, '1')
-	window.localStorage.removeItem(testKey)
+        window.localStorage.setItem(testKey, '1')
+        window.localStorage.removeItem(testKey)
 
-	return true
+        return true
       } catch (error) {
-	return false
+        return false
       }
     },
-    isLocalStorageSupported: function(){
+
+    isLocalStorageSupported: function() {
       if (this._isLocalStorageSupported === null) {
-	this._isLocalStorageSupported = this.checkIfLocalStorageSupported()
+        this._isLocalStorageSupported = this.checkIfLocalStorageSupported()
       }
 
       return this._isLocalStorageSupported
@@ -34,21 +36,22 @@ define(["config"], function(config){
       var ca = document.cookie.split(';')
 
       for (var i=0; i<ca.length; i++) {
-	var c = ca[i]
+        var c = ca[i]
 
-	while (c.charAt(0)==' ')
-	  c = c.substring(1);
+        while (c.charAt(0)==' ')
+          c = c.substring(1);
 
-	if (c.indexOf(name) == 0)
-	  return c.substring(name.length,c.length);
+        if (c.indexOf(name) == 0)
+          return c.substring(name.length,c.length);
       }
 
-      return "";
+      return '';
     },
+
     setCookie: function(cname, cvalue, exdays, cdomain, path) {
       var d = new Date()
       d.setTime(d.getTime() + (exdays * 24 * 60 * 60 * 1000))
-      
+
       var cookie = cname + '=' + cvalue + '; '
       + 'expires=' + d.toUTCString() + '; '
       + 'domain=' + cdomain + '; '
@@ -59,39 +62,28 @@ define(["config"], function(config){
 
     getStoredToken: function () {
       var token;
+
+      // Migrate token from localStorage to cookie
+      // (we'll leave this in prod for a couple of weeks until everyone seamlessly have a cookie)
       if (this.isLocalStorageSupported()) {
-	token =  window.localStorage.getItem('authToken')
-      } 
+        token = window.localStorage.getItem('authToken')
+        window.localStorage.removeItem('authToken')
+      }
       if (token) {
-      	this.storeToken(token)
-	return token
+        this.storeToken(token)
+        return token
       } else {
-	return this.getCookie(config.auth.tokenPrefix + 'authToken')
+        return this.getCookie(config.auth.tokenPrefix + 'authToken')
       }
     },
 
     storeToken: function(token) {
-      var hostname = window.location.hostname.split('.')
-      hostname.reverse()
-      if(token == null){
-	if (this.isLocalStorageSupported()) 
-	  window.localStorage.removeItem('authToken') 
-	
-	this.setCookie(
-	  config.auth.tokenPrefix + 'authToken',
-	  token,
-	  -1,
-	  hostname[1] + '.' + hostname[0],
-	  '/'
-	)	
-	return
-      }
       this.setCookie(
-	config.auth.tokenPrefix + 'authToken',
-	token, 
-	365, 
-	hostname[1] + '.' + hostname[0],
-	'/'
+        config.auth.tokenPrefix + 'authToken',
+        token,
+        365,
+        config.auth.cookieDomain,
+        '/'
       )
     }
   }

--- a/public/js/config.js
+++ b/public/js/config.js
@@ -6,7 +6,8 @@ define({
   host: "http://localhost:3000",
 
   auth: {
-    'tokenPrefix': 'test'
+    cookieDomain: 'localhost',
+    tokenPrefix: 'test_'
   },
 
   waitSeconds: 0,


### PR DESCRIPTION
Ping @SiTLar and @berkus.

Besides some cleanup and refactoring, there's some logic changed, please pay attention.

I tested it on my server, seems fine. The token is removed from localStorage and added to the cookies. Auth migration works seamlessly, without kicking out logged-in user. Further logout/login work just fine too.

Please test it too, on your own servers or on micropeppa, as much as you can.
