### PR TITLE
Some details and user-friendly display of "Upload failed" errors

### DIFF
--- a/public/js/app/controllers/PostController.js
+++ b/public/js/app/controllers/PostController.js
@@ -11,6 +11,11 @@ define(["app/app",
       return post.get('attachments').isAny('id', null)
     }.property('model.attachments.[]'),
 
+    // 'uploadErrors' should be an instance property (set on init), not a prototype property
+    setupUploadErrors: function() {
+      this.set('uploadErrors', []);
+    }.on('init'),
+
     // Remove attachment on edit-post
     removeAttachment: function(attachmentId) {
       var post = this.get('model')
@@ -33,6 +38,7 @@ define(["app/app",
         // Add a throbber (placeholder object, to show uploading progress)
         var post = this.get('model')
         var attachmentList = post.get('attachments')
+        var uploadErrors = this.get('uploadErrors')
         var throbber = this.store.createRecord('attachment', { fileName: file.name })
         var throbberIndex = attachmentList.length
         attachmentList.pushObject(throbber)
@@ -49,9 +55,19 @@ define(["app/app",
             if (e.responseJSON && e.responseJSON.message) {
               errorDetails = e.responseJSON.message
             }
+            uploadErrors.pushObject({
+              fileName: file.name,
+              message: 'Upload failed: ' + errorDetails
+            })
             console.log('Upload failed: ' + errorDetails)
+
             attachmentList.removeAt(throbberIndex, 1)
           })
+      },
+
+      // Clear uploadErrors on create-post
+      clearUploadErrors: function() {
+        this.set('uploadErrors', [])
       },
 
       startEdit: function() {

--- a/public/js/app/controllers/PostController.js
+++ b/public/js/app/controllers/PostController.js
@@ -45,7 +45,11 @@ define(["app/app",
             attachmentList.replace(throbberIndex, 1, [ attachment ])
           })
           .catch(function(e) {
-            console.log('Upload failed.')
+            var errorDetails = 'Unspecified error'
+            if (e.responseJSON && e.responseJSON.message) {
+              errorDetails = e.responseJSON.message
+            }
+            console.log('Upload failed: ' + errorDetails)
             attachmentList.removeAt(throbberIndex, 1)
           })
       },

--- a/public/js/app/controllers/TimelineGenericController.js
+++ b/public/js/app/controllers/TimelineGenericController.js
@@ -138,7 +138,11 @@ define(["config",
             attachmentList.replace(throbberIndex, 1, [ attachment ])
           })
           .catch(function(e) {
-            console.log('Upload failed.')
+            var errorDetails = 'Unspecified error'
+            if (e.responseJSON && e.responseJSON.message) {
+              errorDetails = e.responseJSON.message
+            }
+            console.log('Upload failed: ' + errorDetails)
             attachmentList.removeAt(throbberIndex, 1)
           })
       },

--- a/public/js/app/controllers/TimelineGenericController.js
+++ b/public/js/app/controllers/TimelineGenericController.js
@@ -26,6 +26,11 @@ define(["config",
       this.set('attachments', []);
     }.on('init'),
 
+    // 'uploadErrors' should be an instance property (set on init), not a prototype property
+    setupUploadErrors: function() {
+      this.set('uploadErrors', []);
+    }.on('init'),
+
     didRequestRange: function(options) {
       this.transitionToRoute({ queryParams: { offset: options.offset } })
     },
@@ -127,6 +132,7 @@ define(["config",
 
         // Add a throbber (placeholder object, to show uploading progress)
         var attachmentList = this.get('attachments')
+        var uploadErrors = this.get('uploadErrors')
         var throbber = this.store.createRecord('attachment', { fileName: file.name })
         var throbberIndex = attachmentList.length
         attachmentList.pushObject(throbber)
@@ -142,9 +148,19 @@ define(["config",
             if (e.responseJSON && e.responseJSON.message) {
               errorDetails = e.responseJSON.message
             }
+            uploadErrors.pushObject({
+              fileName: file.name,
+              message: 'Upload failed: ' + errorDetails
+            })
             console.log('Upload failed: ' + errorDetails)
+
             attachmentList.removeAt(throbberIndex, 1)
           })
+      },
+
+      // Clear uploadErrors on create-post
+      clearUploadErrors: function() {
+        this.set('uploadErrors', [])
       },
 
       create: function() {

--- a/public/js/app/templates/postTemplate.handlebars
+++ b/public/js/app/templates/postTemplate.handlebars
@@ -61,6 +61,19 @@
       </div>
     {{/if}}
 
+    {{#if controller.uploadErrors}}
+      <div class="upload-errors">
+        <div class="clear-upload-errors fa fa-times" title="Clear errors" {{action 'clearUploadErrors'}}></div>
+
+        {{#each error in controller.uploadErrors}}
+          <div class="upload-error">
+            {{error.message}}
+            <div class="file-name">{{error.fileName}}</div>
+          </div>
+        {{/each}}
+      </div>
+    {{/if}}
+
     <div class="info">
       {{#if content.isDirects}}
         <span>

--- a/public/js/app/templates/submitPostTemplate.handlebars
+++ b/public/js/app/templates/submitPostTemplate.handlebars
@@ -48,6 +48,19 @@
           </div>
         {{/if}}
 
+        {{#if controller.uploadErrors}}
+          <div class="upload-errors">
+            <div class="clear-upload-errors fa fa-times" title="Clear errors" {{action 'clearUploadErrors'}}></div>
+
+            {{#each error in controller.uploadErrors}}
+              <div class="upload-error">
+                {{error.message}}
+                <div class="file-name">{{error.fileName}}</div>
+              </div>
+            {{/each}}
+          </div>
+        {{/if}}
+
         {{view 'create-attachment'}}
       </div>
       <div class="col-md-2">

--- a/themes/fresh/post.scss
+++ b/themes/fresh/post.scss
@@ -378,6 +378,40 @@
     }
   }
 
+  .upload-errors {
+    position: relative;
+    background-color: #fbb;
+    padding: 1px 6px;
+    margin: 0 8px 8px 0;
+
+    .clear-upload-errors {
+      display: block !important;
+      position: absolute;
+      right: 0;
+      top: 0;
+      cursor: pointer;
+      color: #966;
+      font-size: 20px;
+      padding: 4px 6px 5px 7px;
+      z-index: 100;
+
+      &:hover {
+        color: #433;
+      }
+    }
+
+    .upload-error {
+      color: #433;
+      font-size: 14px;
+      margin: 3px 0;
+
+      .file-name {
+        color: #966;
+        font-size: 12px;
+      }
+    }
+  }
+
   .info,
   .comments {
     opacity: 0.2;

--- a/themes/helvetica/post.scss
+++ b/themes/helvetica/post.scss
@@ -387,6 +387,40 @@
     }
   }
 
+  .upload-errors {
+    position: relative;
+    background-color: #fbb;
+    padding: 1px 6px;
+    margin: 0 8px 8px 0;
+
+    .clear-upload-errors {
+      display: block !important;
+      position: absolute;
+      right: 0;
+      top: 0;
+      cursor: pointer;
+      color: #966;
+      font-size: 20px;
+      padding: 4px 6px 5px 7px;
+      z-index: 100;
+
+      &:hover {
+        color: #433;
+      }
+    }
+
+    .upload-error {
+      color: #433;
+      font-size: 14px;
+      margin: 3px 0;
+
+      .file-name {
+        color: #966;
+        font-size: 12px;
+      }
+    }
+  }
+
   .info,
   .comments {
     opacity: 0.2;

--- a/themes/shared/create-post.scss
+++ b/themes/shared/create-post.scss
@@ -192,6 +192,40 @@
     }
   }
 
+  .upload-errors {
+    position: relative;
+    background-color: #fbb;
+    padding: 1px 6px;
+    margin: 0 8px 8px 0;
+
+    .clear-upload-errors {
+      display: block !important;
+      position: absolute;
+      right: 0;
+      top: 0;
+      cursor: pointer;
+      color: #966;
+      font-size: 20px;
+      padding: 4px 6px 5px 7px;
+      z-index: 100;
+
+      &:hover {
+        color: #433;
+      }
+    }
+
+    .upload-error {
+      color: #433;
+      font-size: 14px;
+      margin: 3px 0;
+
+      .file-name {
+        color: #966;
+        font-size: 12px;
+      }
+    }
+  }
+
   .create-attachment {
     cursor: pointer;
     color: #555;


### PR DESCRIPTION
First commit adds some details for the "Upload failed" error (see the server-side PR [over there](https://github.com/pepyatka/pepyatka-server/pull/295)) to the `console.log` message.

Other two commits add user-friendly display of these errors (because nobody looks into their console).

Screenshot with one failed image:

<img width="710" alt="2015-11-09 01-35-32 frf-upload-errors" src="https://cloud.githubusercontent.com/assets/1071933/11023934/59968a06-8685-11e5-9131-19a2c3584622.png">

Screenshot with many failed images:

<img width="711" alt="2015-11-09 01-38-36 frf-upload-errors-2" src="https://cloud.githubusercontent.com/assets/1071933/11023938/6e9273c0-8685-11e5-99cf-18305114bf54.png">
